### PR TITLE
Add man_made=cutline into conversion mapping and theme

### DIFF
--- a/theme-base/src/main/assets/themes/mapsforgeV3/base/theme.xml
+++ b/theme-base/src/main/assets/themes/mapsforgeV3/base/theme.xml
@@ -2984,8 +2984,8 @@ version 2.4.0
 					<area fill="#ebeade" />
 				</rule>
 			</rule>
-			<rule e="way" k="man_made" v="cutline" zoom_min="15">
-				<line stroke="#b38d5d" stroke-width="0.2dp" stroke-dasharray="5,5" stroke-linecap="butt" />
+			<rule cat="base_topo" e="way" k="man_made" v="cutline" zoom_min="15">
+				<line stroke="#b38d5d" stroke-width="0.3dp" stroke-dasharray="7,5" stroke-linecap="butt" />
 			</rule>
 		</rule>		
 		

--- a/theme-base/src/main/assets/themes/mapsforgeV3/base/theme.xml
+++ b/theme-base/src/main/assets/themes/mapsforgeV3/base/theme.xml
@@ -2984,6 +2984,9 @@ version 2.4.0
 					<area fill="#ebeade" />
 				</rule>
 			</rule>
+			<rule e="way" k="man_made" v="cutline" zoom_min="15">
+				<line stroke="#b38d5d" stroke-width="0.2dp" stroke-dasharray="5,5" stroke-linecap="butt" />
+			</rule>
 		</rule>		
 		
 		<!-- walls barries-->

--- a/various/tag-mapping-xml/tag-mapping-tourist.xml
+++ b/various/tag-mapping-xml/tag-mapping-tourist.xml
@@ -785,6 +785,7 @@
 		
 		<osm-tag key="man_made" value="adit" zoom-appear="14" />
 		<osm-tag key="man_made" value="cross" zoom-appear="14" />
+		 <osm-tag key="man_made" value="cutline" zoom-appear="14" />
 		<osm-tag key="man_made" value="lighthouse" zoom-appear="13" />
 		<osm-tag key="man_made" value="mineshaft" zoom-appear="14" />
 		<osm-tag key="man_made" value="pier" zoom-appear="15" />


### PR DESCRIPTION
Cutlines might be highly useful for forest hikers, as they sometimes provide a means of traversing the forest where roads are not present/mapped/outdated.

[Screenshots with cutlines enabled](https://github.com/darauble/Locus-Map-DIY/blob/main/screenshots/LocusMap%20-%20cutlines.jpg)